### PR TITLE
AppOpsService: Watch op mode changes when an AppOp restriction dies

### DIFF
--- a/services/core/java/com/android/server/appop/AppOpsService.java
+++ b/services/core/java/com/android/server/appop/AppOpsService.java
@@ -705,7 +705,11 @@ public class AppOpsService extends IAppOpsService.Stub {
         public void binderDied() {
             synchronized (AppOpsService.this) {
                 for (int i=mStartedOps.size()-1; i>=0; i--) {
-                    finishOperationLocked(mStartedOps.get(i), /*finishNested*/ true);
+                    final Op op = mStartedOps.get(i);
+                    finishOperationLocked(op, /*finishNested*/ true);
+                    if (op.startNesting <= 0) {
+                        scheduleOpActiveChangedIfNeededLocked(op.op, op.uid, op.packageName, false);
+                    }
                 }
                 mClients.remove(mAppToken);
             }


### PR DESCRIPTION
On binder death, ensure that any associated watched ops are not left
dangling in an active state.

Test: manual, ops states are now propagated properly after apps are killed
Change-Id: I060d9fabc555e609ad529c612fcb7712f0cea0a6
Merged-In: Ied66c7f49e1c483870048563d08fb57410f004ef